### PR TITLE
feat: Homebrew対応 - brew installでのインストールを可能に

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,63 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update formula for (without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="v${{ github.event.inputs.version }}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+
+      - name: Wait for release assets
+        if: github.event_name == 'release'
+        run: sleep 60
+
+      - name: Update formula
+        run: |
+          ./scripts/update-formula.sh "${{ steps.version.outputs.VERSION }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Homebrew formula to ${{ steps.version.outputs.VERSION }}"
+          title: "Update Homebrew formula to ${{ steps.version.outputs.VERSION }}"
+          body: |
+            This PR updates the Homebrew formula to version ${{ steps.version.outputs.VERSION }}.
+            
+            ## Changes
+            - Updated version number
+            - Updated SHA256 checksums for all platforms
+            
+            ## Checklist
+            - [ ] SHA256 checksums verified
+            - [ ] Formula syntax validated
+            - [ ] Test installation locally
+          branch: update-formula-${{ steps.version.outputs.VERSION }}
+          delete-branch: true
+          labels: |
+            homebrew
+            automation

--- a/Formula/kilar.rb
+++ b/Formula/kilar.rb
@@ -1,0 +1,41 @@
+class Kilar < Formula
+  desc "Powerful CLI tool for managing port processes"
+  homepage "https://github.com/polidog/kilar"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/polidog/kilar/releases/download/v#{version}/kilar-#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_MACOS_INTEL"
+    else
+      url "https://github.com/polidog/kilar/releases/download/v#{version}/kilar-#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_MACOS_ARM"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/polidog/kilar/releases/download/v#{version}/kilar-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_LINUX_X86_64"
+    else
+      url "https://github.com/polidog/kilar/releases/download/v#{version}/kilar-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_LINUX_ARM"
+    end
+  end
+
+  def install
+    bin.install "kilar"
+  end
+
+  test do
+    # Test basic command execution
+    assert_match "kilar #{version}", shell_output("#{bin}/kilar --version")
+    
+    # Test help command
+    assert_match "A powerful CLI tool for managing port processes", shell_output("#{bin}/kilar --help")
+    
+    # Test list command (should work without errors)
+    system "#{bin}/kilar", "list", "--help"
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 # Makefile for kilar
 
-.PHONY: help build test clean release check fmt clippy audit install
+.PHONY: help build test clean release check fmt clippy audit install tap-setup tap-update
 
 # Default target
 help:
 	@echo "Available targets:"
-	@echo "  build     - Build the project in debug mode"
-	@echo "  test      - Run all tests"
-	@echo "  clean     - Clean build artifacts"
-	@echo "  release   - Build optimized release binary"
-	@echo "  check     - Run cargo check"
-	@echo "  fmt       - Format code"
-	@echo "  clippy    - Run clippy lints"
-	@echo "  audit     - Run security audit"
-	@echo "  install   - Install the binary locally"
-	@echo "  ci        - Run all CI checks"
+	@echo "  build      - Build the project in debug mode"
+	@echo "  test       - Run all tests"
+	@echo "  clean      - Clean build artifacts"
+	@echo "  release    - Build optimized release binary"
+	@echo "  check      - Run cargo check"
+	@echo "  fmt        - Format code"
+	@echo "  clippy     - Run clippy lints"
+	@echo "  audit      - Run security audit"
+	@echo "  install    - Install the binary locally"
+	@echo "  ci         - Run all CI checks"
+	@echo "  tap-setup  - Setup Homebrew tap repository"
+	@echo "  tap-update - Update Homebrew formula (requires version)"
 
 # Build targets
 build:
@@ -85,3 +87,16 @@ build-macos-arm:
 # Build all release targets (requires cross-compilation setup)
 build-all: release build-linux build-windows build-macos-intel build-macos-arm
 	@echo "All release binaries built!"
+
+# Homebrew tap management
+tap-setup:
+	@echo "Setting up Homebrew tap repository..."
+	@./scripts/setup-homebrew-tap.sh
+
+tap-update:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make tap-update VERSION=0.1.0"; \
+		exit 1; \
+	fi
+	@echo "Updating Homebrew formula for version $(VERSION)..."
+	@./scripts/update-formula.sh $(VERSION)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ A powerful CLI tool for managing port processes on your system. Quickly find and
 
 ## Installation 📦
 
+### Using Homebrew (macOS/Linux)
+
+```bash
+# Add the tap and install
+brew tap polidog/tap
+brew install kilar
+
+# Or install directly
+brew install polidog/tap/kilar
+```
+
+### Using cargo
+
+```bash
+cargo install kilar
+```
+
 ### From source
 
 ```bash
@@ -21,12 +38,6 @@ git clone https://github.com/polidog/kilar.git
 cd kilar
 cargo build --release
 sudo cp target/release/kilar /usr/local/bin/
-```
-
-### Using cargo
-
-```bash
-cargo install kilar
 ```
 
 ## Usage 🚀

--- a/docs/HOMEBREW_SETUP.md
+++ b/docs/HOMEBREW_SETUP.md
@@ -1,0 +1,196 @@
+# Homebrew Tap Setup Guide
+
+This guide explains how to set up and maintain the Homebrew tap for kilar.
+
+## Prerequisites
+
+- GitHub CLI (`brew install gh`)
+- GitHub account with repository creation permissions
+- Homebrew installed on your system
+
+## Initial Setup
+
+### 1. Automatic Setup
+
+Run the setup script to create the tap repository:
+
+```bash
+make tap-setup
+```
+
+Or directly:
+
+```bash
+./scripts/setup-homebrew-tap.sh
+```
+
+This will:
+1. Create a new repository `homebrew-tap` on GitHub
+2. Set up the proper directory structure
+3. Copy the formula file
+4. Push everything to GitHub
+
+### 2. Manual Setup
+
+If you prefer to set up manually:
+
+1. Create a new GitHub repository named `homebrew-tap`
+2. Clone it locally
+3. Create the Formula directory structure:
+
+```bash
+git clone https://github.com/polidog/homebrew-tap.git
+cd homebrew-tap
+mkdir -p Formula
+cp ../kilar/Formula/kilar.rb Formula/
+cp ../kilar/homebrew-tap-README.md README.md
+git add .
+git commit -m "Initial tap setup"
+git push origin main
+```
+
+## Updating the Formula
+
+### After a New Release
+
+When you create a new release on GitHub:
+
+1. The GitHub Action will automatically create a PR to update the formula
+2. Review and merge the PR
+
+### Manual Update
+
+To manually update the formula with new SHA256 checksums:
+
+```bash
+# Update to version 0.1.1
+make tap-update VERSION=0.1.1
+```
+
+Or directly:
+
+```bash
+./scripts/update-formula.sh v0.1.1
+```
+
+## Testing the Tap
+
+### Local Testing
+
+Before pushing changes, test the formula locally:
+
+```bash
+# Add your local tap
+brew tap polidog/tap path/to/homebrew-tap
+
+# Test installation
+brew install --verbose --debug kilar
+
+# Run tests
+brew test kilar
+
+# Audit the formula
+brew audit --strict kilar
+```
+
+### Clean Installation Test
+
+```bash
+# Remove existing installation
+brew uninstall kilar 2>/dev/null || true
+brew untap polidog/tap 2>/dev/null || true
+
+# Fresh install
+brew tap polidog/tap
+brew install kilar
+kilar --version
+```
+
+## Formula Structure
+
+The formula (`Formula/kilar.rb`) contains:
+
+- **Metadata**: Description, homepage, version, license
+- **Download URLs**: Platform-specific binary URLs
+- **SHA256 Checksums**: For integrity verification
+- **Installation Instructions**: How to install the binary
+- **Tests**: Basic functionality tests
+
+## Troubleshooting
+
+### SHA256 Mismatch
+
+If users report SHA256 mismatch errors:
+
+1. Download the release artifacts manually
+2. Calculate correct SHA256: `sha256sum filename.tar.gz`
+3. Update the formula with correct checksums
+4. Push the fix
+
+### Formula Syntax Errors
+
+Validate the formula:
+
+```bash
+# Check Ruby syntax
+ruby -c Formula/kilar.rb
+
+# Brew audit
+brew audit --strict Formula/kilar.rb
+```
+
+### Installation Failures
+
+Common issues and solutions:
+
+1. **Permission denied**: Ensure proper file permissions in the tar.gz
+2. **Binary not found**: Check the tar.gz structure matches formula expectations
+3. **Wrong architecture**: Verify platform detection logic in formula
+
+## Maintenance Checklist
+
+### For Each Release
+
+- [ ] Create GitHub release with proper version tag (v0.1.0)
+- [ ] Wait for release artifacts to be uploaded
+- [ ] Verify GitHub Action creates update PR
+- [ ] Test installation with new version
+- [ ] Merge PR after successful tests
+- [ ] Announce update to users
+
+### Periodic Tasks
+
+- [ ] Test formula on different platforms
+- [ ] Update formula for Homebrew best practices
+- [ ] Monitor user issues and feedback
+- [ ] Keep documentation up to date
+
+## User Installation
+
+Users can install kilar via Homebrew:
+
+```bash
+# Standard installation
+brew tap polidog/tap
+brew install kilar
+
+# One-line installation
+brew install polidog/tap/kilar
+
+# Update to latest version
+brew update
+brew upgrade kilar
+```
+
+## Resources
+
+- [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Homebrew Taps Documentation](https://docs.brew.sh/Taps)
+- [GitHub Actions for Homebrew](https://github.com/Homebrew/actions)
+
+## Support
+
+For issues with the Homebrew formula:
+1. Check [existing issues](https://github.com/polidog/kilar/issues)
+2. Create a new issue with the `homebrew` label
+3. Include error messages and system information

--- a/homebrew-tap-README.md
+++ b/homebrew-tap-README.md
@@ -1,0 +1,73 @@
+# Homebrew Tap for kilar
+
+This repository contains the Homebrew formula for [kilar](https://github.com/polidog/kilar), a powerful CLI tool for managing port processes.
+
+## Installation
+
+```bash
+# Add the tap
+brew tap polidog/tap https://github.com/polidog/homebrew-tap.git
+
+# Install kilar
+brew install kilar
+```
+
+Or install directly:
+
+```bash
+brew install polidog/tap/kilar
+```
+
+## Updating
+
+```bash
+brew update
+brew upgrade kilar
+```
+
+## Uninstallation
+
+```bash
+brew uninstall kilar
+brew untap polidog/tap  # Optional: remove the tap
+```
+
+## Formula Structure
+
+This tap repository should have the following structure:
+
+```
+homebrew-tap/
+├── README.md
+└── Formula/
+    └── kilar.rb
+```
+
+## Setting up the tap repository
+
+1. Create a new GitHub repository named `homebrew-tap`
+2. Copy the `Formula` directory from the main kilar repository
+3. Push to GitHub
+
+```bash
+# Create new repository on GitHub named "homebrew-tap"
+git clone https://github.com/polidog/homebrew-tap.git
+cd homebrew-tap
+
+# Copy Formula directory from kilar repo
+cp -r ../kilar/Formula .
+cp ../kilar/homebrew-tap-README.md README.md
+
+# Commit and push
+git add .
+git commit -m "Initial tap setup for kilar"
+git push origin main
+```
+
+## Maintenance
+
+The formula is automatically updated when a new release is published in the main kilar repository through GitHub Actions.
+
+## License
+
+MIT License - See [LICENSE](https://github.com/polidog/kilar/blob/main/LICENSE) in the main repository.

--- a/scripts/setup-homebrew-tap.sh
+++ b/scripts/setup-homebrew-tap.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -e
+
+echo "Setting up Homebrew tap repository for kilar..."
+echo ""
+echo "This script will help you create a homebrew-tap repository on GitHub."
+echo ""
+
+# Check if gh CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI (gh) is not installed."
+    echo "Please install it first: brew install gh"
+    exit 1
+fi
+
+# Check if authenticated
+if ! gh auth status &> /dev/null; then
+    echo "Error: Not authenticated with GitHub."
+    echo "Please run: gh auth login"
+    exit 1
+fi
+
+# Get current directory
+CURRENT_DIR=$(pwd)
+TEMP_DIR=$(mktemp -d)
+
+echo "Creating homebrew-tap repository on GitHub..."
+
+# Create the repository
+gh repo create homebrew-tap --public --description "Homebrew tap for kilar - A powerful CLI tool for managing port processes" || {
+    echo "Repository might already exist or creation failed."
+    echo "If it exists, we'll continue with the setup."
+}
+
+echo ""
+echo "Cloning homebrew-tap repository..."
+cd "$TEMP_DIR"
+
+# Clone the repository
+if gh repo clone polidog/homebrew-tap 2>/dev/null; then
+    cd homebrew-tap
+else
+    echo "Failed to clone repository. It might not exist yet."
+    echo "Creating local repository..."
+    mkdir homebrew-tap
+    cd homebrew-tap
+    git init
+    git remote add origin https://github.com/polidog/homebrew-tap.git
+fi
+
+echo ""
+echo "Setting up tap structure..."
+
+# Copy Formula directory
+cp -r "$CURRENT_DIR/Formula" .
+
+# Copy and rename README
+if [ -f "$CURRENT_DIR/homebrew-tap-README.md" ]; then
+    cp "$CURRENT_DIR/homebrew-tap-README.md" README.md
+else
+    echo "# Homebrew Tap for kilar" > README.md
+    echo "" >> README.md
+    echo "This repository contains the Homebrew formula for [kilar](https://github.com/polidog/kilar)." >> README.md
+    echo "" >> README.md
+    echo "## Installation" >> README.md
+    echo "" >> README.md
+    echo '```bash' >> README.md
+    echo "brew tap polidog/tap" >> README.md
+    echo "brew install kilar" >> README.md
+    echo '```' >> README.md
+fi
+
+# Create .gitignore
+cat > .gitignore << 'EOF'
+.DS_Store
+*.swp
+*.swo
+*~
+EOF
+
+echo ""
+echo "Committing and pushing to GitHub..."
+
+git add .
+git commit -m "Initial setup of Homebrew tap for kilar" || {
+    echo "Nothing to commit or commit failed."
+}
+
+# Push to GitHub
+git branch -M main
+git push -u origin main || {
+    echo "Push failed. You may need to set up the repository manually."
+    echo "Repository location: $TEMP_DIR/homebrew-tap"
+}
+
+echo ""
+echo "✅ Homebrew tap repository setup complete!"
+echo ""
+echo "Repository: https://github.com/polidog/homebrew-tap"
+echo ""
+echo "Users can now install kilar with:"
+echo "  brew tap polidog/tap"
+echo "  brew install kilar"
+echo ""
+echo "Or directly:"
+echo "  brew install polidog/tap/kilar"
+echo ""
+echo "Note: You'll need to update the SHA256 checksums in Formula/kilar.rb"
+echo "after creating a release. Use: ./scripts/update-formula.sh <version>"
+
+# Return to original directory
+cd "$CURRENT_DIR"
+
+# Clean up temp directory
+rm -rf "$TEMP_DIR"

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+# Remove 'v' prefix if present
+VERSION=${VERSION#v}
+
+FORMULA_PATH="Formula/kilar.rb"
+TEMP_DIR=$(mktemp -d)
+
+echo "Updating Homebrew formula for version $VERSION..."
+
+# Function to download and calculate SHA256
+calculate_sha256() {
+    local url=$1
+    local filename=$(basename "$url")
+    
+    echo "Downloading $url..."
+    curl -L -o "$TEMP_DIR/$filename" "$url"
+    
+    if [ ! -f "$TEMP_DIR/$filename" ]; then
+        echo "Failed to download $url"
+        return 1
+    fi
+    
+    sha256sum "$TEMP_DIR/$filename" | cut -d' ' -f1
+}
+
+# URLs for different platforms
+BASE_URL="https://github.com/polidog/kilar/releases/download/v${VERSION}"
+MACOS_INTEL_URL="${BASE_URL}/kilar-${VERSION}-x86_64-apple-darwin.tar.gz"
+MACOS_ARM_URL="${BASE_URL}/kilar-${VERSION}-aarch64-apple-darwin.tar.gz"
+LINUX_X86_URL="${BASE_URL}/kilar-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+LINUX_ARM_URL="${BASE_URL}/kilar-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+
+# Calculate SHA256 for each platform
+echo "Calculating SHA256 checksums..."
+MACOS_INTEL_SHA256=$(calculate_sha256 "$MACOS_INTEL_URL") || true
+MACOS_ARM_SHA256=$(calculate_sha256 "$MACOS_ARM_URL") || true
+LINUX_X86_SHA256=$(calculate_sha256 "$LINUX_X86_URL") || true
+LINUX_ARM_SHA256=$(calculate_sha256 "$LINUX_ARM_URL") || true
+
+# Clean up temp directory
+rm -rf "$TEMP_DIR"
+
+# Update the formula file
+echo "Updating formula file..."
+
+# Update version
+sed -i.bak "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA_PATH"
+
+# Update SHA256 values
+if [ -n "$MACOS_INTEL_SHA256" ]; then
+    sed -i.bak "s/sha256 \"PLACEHOLDER_SHA256_MACOS_INTEL\"/sha256 \"${MACOS_INTEL_SHA256}\"/" "$FORMULA_PATH"
+    sed -i.bak "s/sha256 \"[a-f0-9]*\" # x86_64-apple-darwin/sha256 \"${MACOS_INTEL_SHA256}\" # x86_64-apple-darwin/" "$FORMULA_PATH"
+fi
+
+if [ -n "$MACOS_ARM_SHA256" ]; then
+    sed -i.bak "s/sha256 \"PLACEHOLDER_SHA256_MACOS_ARM\"/sha256 \"${MACOS_ARM_SHA256}\"/" "$FORMULA_PATH"
+    sed -i.bak "s/sha256 \"[a-f0-9]*\" # aarch64-apple-darwin/sha256 \"${MACOS_ARM_SHA256}\" # aarch64-apple-darwin/" "$FORMULA_PATH"
+fi
+
+if [ -n "$LINUX_X86_SHA256" ]; then
+    sed -i.bak "s/sha256 \"PLACEHOLDER_SHA256_LINUX_X86_64\"/sha256 \"${LINUX_X86_SHA256}\"/" "$FORMULA_PATH"
+    sed -i.bak "s/sha256 \"[a-f0-9]*\" # x86_64-unknown-linux-gnu/sha256 \"${LINUX_X86_SHA256}\" # x86_64-unknown-linux-gnu/" "$FORMULA_PATH"
+fi
+
+if [ -n "$LINUX_ARM_SHA256" ]; then
+    sed -i.bak "s/sha256 \"PLACEHOLDER_SHA256_LINUX_ARM\"/sha256 \"${LINUX_ARM_SHA256}\"/" "$FORMULA_PATH"
+    sed -i.bak "s/sha256 \"[a-f0-9]*\" # aarch64-unknown-linux-gnu/sha256 \"${LINUX_ARM_SHA256}\" # aarch64-unknown-linux-gnu/" "$FORMULA_PATH"
+fi
+
+# Remove backup files
+rm -f "${FORMULA_PATH}.bak"
+
+echo "Formula updated successfully!"
+echo ""
+echo "SHA256 checksums:"
+echo "  macOS Intel:  ${MACOS_INTEL_SHA256:-Not available}"
+echo "  macOS ARM:    ${MACOS_ARM_SHA256:-Not available}"
+echo "  Linux x86_64: ${LINUX_X86_SHA256:-Not available}"
+echo "  Linux ARM:    ${LINUX_ARM_SHA256:-Not available}"


### PR DESCRIPTION
## 概要
Homebrewを使ったインストールをサポートする機能を追加しました。これにより、macOSとLinuxユーザーは簡単に`kilar`をインストールできるようになります。

## 変更内容
### ✨ 新機能
- **Homebrew Formula** (`Formula/kilar.rb`)
  - macOS (Intel/Apple Silicon) とLinux対応
  - プラットフォーム自動検出
  - SHA256チェックサム検証

- **自動更新システム**
  - `scripts/update-formula.sh` - リリース時のSHA256自動計算
  - `.github/workflows/update-formula.yml` - 自動PR作成ワークフロー

- **Tap管理ツール**
  - `scripts/setup-homebrew-tap.sh` - tapリポジトリの自動セットアップ
  - Makefileタスク (`make tap-setup`, `make tap-update`)

### 📚 ドキュメント
- README.mdにHomebrewインストール方法を追加
- `docs/HOMEBREW_SETUP.md` - 詳細なセットアップ・メンテナンスガイド
- `homebrew-tap-README.md` - tapリポジトリ用README

## インストール方法
```bash
# Tapを追加してインストール
brew tap polidog/tap
brew install kilar

# または直接インストール
brew install polidog/tap/kilar
```

## セットアップ手順
1. このPRをマージ
2. `make tap-setup` を実行してtapリポジトリを作成
3. リリース作成時に自動でformulaが更新される

## テストプラン
- [ ] Formula構文の検証 (`ruby -c Formula/kilar.rb`)
- [ ] tapリポジトリのセットアップスクリプトの動作確認
- [ ] formula更新スクリプトの動作確認
- [ ] GitHub Actionsワークフローの検証

## 関連Issue
- Homebrew対応の要望

🤖 Generated with [Claude Code](https://claude.ai/code)