### PR TITLE
fix: Fix ss command parsing bugs on Linux systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "kilar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -264,8 +264,34 @@ All commands support JSON output for scripting and automation:
 
 ## Requirements 📋
 
-- **macOS/Linux**: `lsof` command (usually pre-installed)
-- **Permissions**: Some operations may require sudo privileges
+### System Tools
+
+`kilar` requires one of the following system tools to detect port usage:
+
+- **`lsof`** (recommended) - Usually pre-installed on macOS, optional on Linux
+- **`ss`** (Linux fallback) - Part of `iproute2` package, typically pre-installed on most Linux distributions
+- **`netstat`** (alternative fallback) - Available on most systems
+
+**Installation instructions for Linux:**
+
+```bash
+# Arch Linux / Manjaro
+sudo pacman -S lsof  # Optional, ss is already available via iproute2
+
+# Debian / Ubuntu
+sudo apt-get install lsof  # Optional, ss is already available
+
+# Fedora / RHEL / CentOS
+sudo dnf install lsof  # Optional, ss is already available
+```
+
+> **Note**: On Linux systems without `lsof`, `kilar` automatically uses `ss` as a fallback.
+> Only processes owned by the current user will be shown unless running with elevated privileges.
+
+### Permissions
+
+- Some port detection operations may require elevated privileges to see all processes
+- Process termination requires appropriate permissions for the target process
 
 ## Building from Source 🔨
 

--- a/src/port/mod.rs
+++ b/src/port/mod.rs
@@ -558,7 +558,7 @@ impl PortManager {
             }
 
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() < 7 {
+            if parts.len() < 6 {
                 continue;
             }
 
@@ -584,7 +584,7 @@ impl PortManager {
                                 .unwrap_or_else(|_| "Unknown".to_string());
                             {
                                 // Parse the local address to get the port
-                                if let Some(local_addr) = parts.get(4) {
+                                if let Some(local_addr) = parts.get(3) {
                                     if local_addr.ends_with(&format!(":{}", port)) {
                                         let address = if let Some(colon_pos) = local_addr.rfind(':')
                                         {
@@ -759,17 +759,13 @@ impl PortManager {
         for line in output.lines().skip(1) {
             // ヘッダー行をスキップ
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() < 7 {
+            if parts.len() < 6 {
                 continue;
             }
 
             let protocol = parts[0].to_lowercase();
-            let local_address = parts[4];
-            let process_info = if parts.len() > 6 {
-                parts[6]
-            } else {
-                continue;
-            };
+            let local_address = parts[3];
+            let process_info = parts[5..].join(" ");
 
             // ポート番号を抽出
             let port = if let Some(colon_pos) = local_address.rfind(':') {


### PR DESCRIPTION
## 🐛 Problem

`kilar` was not working correctly on Linux systems (especially ArchLinux) where `lsof` is not pre-installed. The tool would fall back to the `ss` command, but critical parsing bugs caused:
- Port detection to fail (showing "available" for ports that were actually in use)
- List command to show "No ports in use found" even when ports were active

## 🔍 Root Cause Analysis

### 1. Incorrect Column Indexing
The `ss` command output has this format:
```
State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
  0      1      2         3                 4              5
```

The code was using:
- ❌ `parts[4]` for local address (this is actually the peer address `*:*`)
- ✅ Should be `parts[3]` for local address (e.g., `*:3000`)

### 2. Process Name Parsing with Spaces
When process names contain spaces (e.g., `"next-server (v1)"`), the `split_whitespace()` function would split them into multiple parts:
```
users:(("next-server (v1",pid=324179,fd=22))
  ↓ split_whitespace()
["users:(("next-server", "(v1",pid=324179,fd=22))"]
```
This caused the parser to fail to extract the PID correctly.

### 3. Incorrect Length Validation
The code was checking `parts.len() < 7`, but the minimum valid length is actually 6 parts.

## ✅ Changes Made

### Code Fixes (`src/port/mod.rs`)
- **Line 561**: `parts.len() < 7` → `parts.len() < 6`
- **Line 587**: `parts.get(4)` → `parts.get(3)` (fix local address extraction)
- **Line 762**: `parts.len() < 7` → `parts.len() < 6`
- **Line 767-768**: Parse local address correctly and join process_info parts with `parts[5..].join(" ")`

### Documentation (`README.md`)
- Enhanced Requirements section with detailed Linux system tool information
- Added installation instructions for `lsof` on various Linux distributions (Arch, Debian/Ubuntu, Fedora/RHEL)
- Clarified that `ss` is automatically used as fallback on Linux
- Added note about permission requirements for viewing all processes

## 🧪 Testing

**Before fix:**
\`\`\`bash
$ cargo run -- check 3000
○ TCP:3000 is available  # ❌ WRONG - port 3000 IS in use

$ cargo run -- list
○ No ports in use found  # ❌ WRONG - 25 ports are listening
\`\`\`

**After fix:**
\`\`\`bash
$ cargo run -- check 3000
✓ TCP:3000 is in use
  PID: 324179
  Process: next-server
  Path: next-server (v16.0.0)

$ cargo run -- list --json | jq '.total_processes'
1  # ✅ Correctly shows port in use
\`\`\`

**Test Results:**
- ✅ All 88 unit tests pass
- ✅ `cargo clippy` reports no warnings
- ✅ Manual testing on ArchLinux confirms both `check` and `list` commands work correctly

## 📊 Impact

- Fixes critical functionality on Linux systems without `lsof`
- Ensures correct port detection using `ss` fallback
- Improves user experience on minimal Linux distributions (Arch, Alpine, etc.)
- No breaking changes - maintains backward compatibility

## 🔗 Related Issues

Resolves the Linux compatibility issues discovered during manual testing on ArchLinux.